### PR TITLE
Rename Reboot normal to OFW in TUI

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -1513,9 +1513,9 @@ ment_t ment_top[] = {
 	MDEF_MENU("Console info", &menu_cinfo),
 	MDEF_CAPTION("---------------", 0xFF444444),
 	MDEF_HANDLER("Reload", ipl_reload),
-	MDEF_HANDLER_EX("Reboot (Normal)", &STATE_REBOOT_BYPASS_FUSES, power_set_state_ex),
-	MDEF_HANDLER_EX("Reboot (RCM)",    &STATE_REBOOT_RCM,          power_set_state_ex),
-	MDEF_HANDLER_EX("Power off",       &STATE_POWER_OFF,           power_set_state_ex),
+	MDEF_HANDLER_EX("Reboot (OFW)", &STATE_REBOOT_BYPASS_FUSES, power_set_state_ex),
+	MDEF_HANDLER_EX("Reboot (RCM)", &STATE_REBOOT_RCM,          power_set_state_ex),
+	MDEF_HANDLER_EX("Power off",    &STATE_POWER_OFF,           power_set_state_ex),
 	MDEF_CAPTION("---------------", 0xFF444444),
 	MDEF_HANDLER("About", _about),
 	MDEF_END()


### PR DESCRIPTION
That otherwise needless change was actually made to change the compiled and compressed size of the payload.

A certain bad chainloader actually corrupts payloads when launched from it. The corruption seems to depend on hekate's actual compressed payload size.